### PR TITLE
Add capability "Refresh" to allow refresh of power and energy data

### DIFF
--- a/devicetypes/smartthings/aeon-home-energy-meter.src/aeon-home-energy-meter.groovy
+++ b/devicetypes/smartthings/aeon-home-energy-meter.src/aeon-home-energy-meter.groovy
@@ -22,6 +22,7 @@ metadata {
 		capability "Power Meter"
 		capability "Configuration"
 		capability "Sensor"
+		capability "Refresh"
 
 		command "reset"
 


### PR DESCRIPTION
The "Refresh" capability was missing from the Aeon Home Energy Meter definition, so the refresh button wasn't working.
